### PR TITLE
Add build artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
-/akka-runtime/target/
-/postgres/target/
-/core/target/
-/k8dns-runtime/target/
-/example/target/
+**/target/


### PR DESCRIPTION
I noticed after checking out the project and running `sbt Test/compile` there are some build artifacts generated that are not covered by the .gitignore
